### PR TITLE
Rename onSyntaxError to onParserError

### DIFF
--- a/libs/sources.js
+++ b/libs/sources.js
@@ -18,7 +18,7 @@ var sources;
  * @type type
  */
 var onSourceChange;
-var onSyntaxError;
+var onParserError;
 var onLoad ;
 
 /**
@@ -29,10 +29,10 @@ var onLoad ;
  * @param callback
  * @returns {undefined}
  */
-var load = function(_filename, cbonSourceChange, cbonSyntaxError, cbonLoad) {
+var load = function(_filename, cbonSourceChange, cbonParserError, cbonLoad) {
 	filename = _filename;
 	onSourceChange = cbonSourceChange;
-	onSyntaxError = cbonSyntaxError;
+	onParserError = cbonParserError;
 	onLoad = cbonLoad;
 	
 	_load();
@@ -78,9 +78,8 @@ var _load = function() {
 	try {
 		var newSources = JSON.parse(fs.readFileSync(filename, 'utf8'));
 	}
-	catch (SyntaxError)
-	{
-		onSyntaxError();
+	catch (e) {
+		onParserError(e);
 		return;
 	}
 

--- a/node-ffmpeg-mpegts-proxy.js
+++ b/node-ffmpeg-mpegts-proxy.js
@@ -52,8 +52,8 @@ var onSourceChange = function() {
 	winston.info('Source definitions have changed, reloading ...');
 };
 
-var onSyntaxError = function() {
-	winston.info('Unable to read source definitions, JSON is malformed');
+var onParserError = function(error) {
+	winston.info('Unable to read source definitions: %s', error.toString());
 };
 
 var onLoad = function(numSources) {
@@ -62,7 +62,7 @@ var onLoad = function(numSources) {
 
 var sourceDefinitions = sources.load(argv.sources, 
 	onSourceChange,
-	onSyntaxError,
+	onParserError,
 	onLoad);
 
 /**


### PR DESCRIPTION
Also print the error instead of assuming the JSON was malformed

Fixes #12